### PR TITLE
Update deps to 0.53.0

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 import  _JSZip from "https://dev.jspm.io/jszip@3.4.0";
-import { WalkOptions, walk } from "https://deno.land/std@v0.51.0/fs/mod.ts";
-import { SEP, join } from "https://deno.land/std@v0.51.0/path/mod.ts";
+import { WalkOptions, walk } from "https://deno.land/std@v0.53.0/fs/mod.ts";
+import { SEP, join } from "https://deno.land/std@v0.53.0/path/mod.ts";
 import {
   InputFileFormat,
   JSZipFileOptions,

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,6 @@
-import { decode, encode } from "https://deno.land/std@v0.51.0/encoding/utf8.ts";
-import { join } from "https://deno.land/std@v0.51.0/path/mod.ts";
-import { assertEquals } from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+import { decode, encode } from "https://deno.land/std@v0.53.0/encoding/utf8.ts";
+import { join } from "https://deno.land/std@v0.53.0/path/mod.ts";
+import { assertEquals } from "https://deno.land/std@v0.53.0/testing/asserts.ts";
 import { JSZip, readZip, zipDir } from "./mod.ts";
 
 // FIXME use tmp directory and clean up.


### PR DESCRIPTION
**What**

This PR bumps std lib version to v0.53.0.

**Why**

Deno v1.0.1 (Deno std v0.52.0) has a breaking change in `Deno.symlink()` core API and some code stops working. Updating the dependent std lib addresses the issue.

- https://github.com/denoland/deno/releases/tag/v1.0.1
- https://github.com/denoland/deno/pull/5533