### PR TITLE
Update fs v and Readme Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ for (const z of zip) {
   console.log(z.name);
 }
 
-console.log(await zip.file("example/Hello.txt").async("string"));
+console.log(await zip.file("Hello.txt").async("string"));
 // "Hello World\n"
 ```

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 import  _JSZip from "https://dev.jspm.io/jszip@3.4.0";
-import { WalkOptions, walk } from "https://deno.land/std@v0.51.0/fs/mod.ts";
+import { WalkOptions, walk } from "https://deno.land/std@v0.54.0/fs/mod.ts";
 import { SEP, join } from "https://deno.land/std@v0.51.0/path/mod.ts";
 import {
   InputFileFormat,

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 import  _JSZip from "https://dev.jspm.io/jszip@3.4.0";
 import { WalkOptions, walk } from "https://deno.land/std@v0.54.0/fs/mod.ts";
-import { SEP, join } from "https://deno.land/std@v0.51.0/path/mod.ts";
+import { SEP, join } from "https://deno.land/std@v0.54.0/path/mod.ts";
 import {
   InputFileFormat,
   JSZipFileOptions,

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,6 @@
-import { decode, encode } from "https://deno.land/std@v0.51.0/encoding/utf8.ts";
-import { join } from "https://deno.land/std@v0.51.0/path/mod.ts";
-import { assertEquals } from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+import { decode, encode } from "https://deno.land/std@v0.54.0/encoding/utf8.ts";
+import { join } from "https://deno.land/std@v0.54.0/path/mod.ts";
+import { assertEquals } from "https://deno.land/std@v0.54.0/testing/asserts.ts";
 import { JSZip, readZip, zipDir } from "./mod.ts";
 
 // FIXME use tmp directory and clean up.


### PR DESCRIPTION
- In lastest DENO v (>= 1.0.4) got error when use fs v 0.51.0
- Wrong path directory in Readme Guide when throw result from zip.file()