### PR TITLE
Fix loadAsync to return Promise<JSZip> as typed.

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -159,17 +159,18 @@ export class JSZip {
   }
 
   /**
-   * Deserialize zip file asynchronously
+   * Load zip data
    *
    * @param data Serialized zip file
    * @param options Options for deserializing
-   * @return Returns promise
+   * @return Returns promise of self
    */
   async loadAsync(
     data: InputFileFormat,
     options?: JSZipLoadOptions,
   ): Promise<JSZip> {
-    return this._z.loadAsync(data, options);
+    await this._z.loadAsync(data, options);
+    return this;
   }
 
   /**


### PR DESCRIPTION
According to the type signature, `loadAsync` should return a promise of the instance (the deno typescript wrapped JSZip instance), not whatever the return type of `this._z.loadAsync` is.

