### PR TITLE
Fixes the issue of missing directories, if the filepath includes backslashes

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,9 +1,9 @@
 import  _JSZip from "https://dev.jspm.io/jszip@3.5.0";
 import { WalkOptions, walk } from "https://deno.land/std@0.99.0/fs/walk.ts";
-import { SEP, join, resolve, dirname } from "https://deno.land/std@0.99.0/path/mod.ts";
+import { SEP, resolve, dirname } from "https://deno.land/std@0.99.0/path/mod.ts";
 import type {
   InputFileFormat,
-  JSZipFileOptions,
+  JSZipAddFileOptions,
   JSZipGeneratorOptions,
   JSZipLoadOptions,
   JSZipObject,
@@ -107,10 +107,13 @@ export class JSZip {
   addFile(
     path: string,
     content?: string | Uint8Array,
-    options?: JSZipFileOptions,
+    options?: JSZipAddFileOptions,
   ): JSZipObject {
+    const replaceBackslashes = options?.replaceBackslashes === undefined || options.replaceBackslashes; 
+    const finalPath = replaceBackslashes ? path.replaceAll("\\", "/") : path;
+
     // @ts-ignores
-    const f = this._z.file(path, content, options);
+    const f = this._z.file(finalPath, content, options);
     return f as JSZipObject;
   }
 

--- a/types.ts
+++ b/types.ts
@@ -58,6 +58,10 @@ export interface JSZipFileOptions {
   unixPermissions?: number | string | null;
 }
 
+export interface JSZipAddFileOptions extends JSZipFileOptions {
+  replaceBackslashes?: boolean;
+}
+
 export interface JSZipGeneratorOptions<T extends OutputType = OutputType> {
   compression?: Compression;
   compressionOptions?: null | {


### PR DESCRIPTION
Related to #29 

Includes changes:
- Test for files added using backslashes
- Option for replacing backslahes with forward flashes in the addFile method. 
- Creating missing directories for files directly in unzip