### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: denolib/setup-deno@master
       with:
-        deno-version: 1.4.6
+        deno-version: 1.16.3
 
     - name: Run tests
       run: deno test --allow-read --allow-write --unstable

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
-import  _JSZip from "https://dev.jspm.io/jszip@3.5.0";
-import { WalkOptions, walk } from "https://deno.land/std@0.99.0/fs/walk.ts";
-import { SEP, join } from "https://deno.land/std@0.99.0/path/mod.ts";
+import  _JSZip from "https://esm.sh/jszip@3.7.1";
+import { WalkOptions, walk } from "https://deno.land/std@0.116.0/fs/walk.ts";
+import { SEP, join } from "https://deno.land/std@0.116.0/path/mod.ts";
 import type {
   InputFileFormat,
   JSZipFileOptions,


### PR DESCRIPTION
@hayd

This PR updates `jszip` and `std` to their latest version.

Fix https://github.com/hayd/deno-zip/issues/32